### PR TITLE
Skip hidden files in directory

### DIFF
--- a/kubernetes_downward_api/parse.py
+++ b/kubernetes_downward_api/parse.py
@@ -24,7 +24,10 @@ def _parse_dir(path):
     metadata = {}
 
     for filename in os.listdir(path):
-        metadata.update(_parse_file(os.path.join(path, filename)))
+        abs_path = os.path.join(path, filename)
+
+        if not filename.startswith('.') and os.path.isfile(abs_path):
+            metadata.update(_parse_file(abs_path))
 
     return metadata
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 
 setup(name="kubernetes-downward-api",
-      version="0.1.0",
+      version="0.1.1",
       description="Parser for Kubernetes Downward API Volumes",
       url="https://github.com/ustudio/kubernetes-downward-api",
       packages=["kubernetes_downward_api"])

--- a/tests/test_kubernetes_downward_api.py
+++ b/tests/test_kubernetes_downward_api.py
@@ -46,6 +46,30 @@ key2="value2"
             'other': 'content'
         }, parse(['/dir']))
 
+    def test_parse_skips_hidden_files_in_directory(self):
+        self.mockfs.add_entries({
+            '/dir/file': 'value',
+            '/dir/.other': 'incorrect',
+            '/dir/other': 'content'
+        })
+
+        self.assertEqual({
+            'file': 'value',
+            'other': 'content'
+        }, parse(['/dir']))
+
+    def test_parse_skips_directories_nested_in_directory(self):
+        self.mockfs.add_entries({
+            '/dir/file': 'value',
+            '/dir/nested/file': 'incorrect',
+            '/dir/other': 'content'
+        })
+
+        self.assertEqual({
+            'file': 'value',
+            'other': 'content'
+        }, parse(['/dir']))
+
     def test_parse_parses_all_paths_given(self):
         self.mockfs.add_entries({
             '/some/file': 'value',


### PR DESCRIPTION
Kubernetes adds some symlinks into the downward API volume that break parsing of directories.

This fixes it twice: first, by ignoring hidden files, and second by not trying to parse directories as files, which should handle future changes to how Downward API volumes work.

@ustudio/dev Please review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ustudio/kubernetes-downward-api/2)
<!-- Reviewable:end -->
