### PR TITLE
Fix parse for blank lines

### DIFF
--- a/kubernetes_downward_api/parse.py
+++ b/kubernetes_downward_api/parse.py
@@ -6,16 +6,23 @@ def _parse_file(path):
     name = os.path.basename(path)
 
     with open(path) as f:
-        first = f.readline()
-
-        if '="' not in first:
-            return {name: first}
-
         data = {}
 
-        for line in [first] + f.readlines():
+        for line in f:
+            line = line.strip()
+
+            if line is '':
+                continue
+
+            if '="' not in line:
+                if len(data) == 0:
+                    return {name: line}
+                raise ValueError(
+                    "Line in complex file lacks key/value pair: {0}".format(
+                        line))
+
             key, value = line.split('=')
-            data[key] = value.strip('"\n')
+            data[key] = value.strip('"')
 
         return {name: data}
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 
 setup(name="kubernetes-downward-api",
-      version="0.1.1",
+      version="0.1.2",
       description="Parser for Kubernetes Downward API Volumes",
       url="https://github.com/ustudio/kubernetes-downward-api",
       packages=["kubernetes_downward_api"])

--- a/tests/test_kubernetes_downward_api.py
+++ b/tests/test_kubernetes_downward_api.py
@@ -26,7 +26,7 @@ class TestKubernetesDownwardAPI(unittest.TestCase):
 key1="value1"
 key2="value2"
 '''
-            })
+        })
 
         self.assertEqual({
             'file': {
@@ -34,6 +34,26 @@ key2="value2"
                 'key2': 'value2'
             }
         }, parse(['/complex/file']))
+
+    def test_parse_ignores_blank_lines(self):
+        self.mockfs.add_entries({
+            '/complex/file': '\n' + '    \n' + 'key1="value1"\n' + ' \n' + 'key2="value2"\n'
+        })
+
+        self.assertEqual({
+            'file': {
+                'key1': 'value1',
+                'key2': 'value2'
+            }
+        }, parse(['/complex/file']))
+
+    def test_parse_raises_if_complex_file_has_line_without_key_value_pair(self):
+        self.mockfs.add_entries({
+            '/complex/file': 'key1="value1"\n' + 'something\n'
+        })
+
+        with self.assertRaises(ValueError):
+            parse(['/complex/file'])
 
     def test_parse_parses_all_files_in_directory(self):
         self.mockfs.add_entries({


### PR DESCRIPTION
Some podinfo files contain blank lines, which were confusing the parser.

@ustudio/dev Please review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ustudio/kubernetes-downward-api/3)
<!-- Reviewable:end -->
